### PR TITLE
Add init.sh to automate more local development steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 flaskenv/*
 .vscode/*
 *.lock
-.idea/vcs.xm
+.idea/*
 certs/
 movr.yaml

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Loads dbinit.sql into your running CockroachDB cluster
+cockroach sql --insecure --url="postgres://root@127.0.0.1:$MOVR_PORT" < dbinit.sql
+
+# Resets .env file, clearing out any variables that were previously set
+git checkout -- .env
+
+# replace <port> with $MOVR_PORT in `.env` for the following env variable:
+#     DB_URI = 'cockroachdb://root@127.0.0.1:<port>/movr'
+# where DB_URI is the SQL connection string needed for SQLAlchemy to connect to CockroachDB.
+sed "s/<port>/$MOVR_PORT/" .env  > temp
+
+# replace API_key with $MOVR_MAPS_API in `.env` for the following env variable:
+#     API_KEY = 'API_key'
+# where API_KEY is Google Maps Static API Key needed to generate maps on the Vehicles page.
+sed "s/API_key/$MOVR_MAPS_API/" temp  > .env
+
+# clean up temp file
+rm temp > /dev/null
+
+echo ".env: DB_URI and API_KEY keys have been set"


### PR DESCRIPTION
Because `cockroach demo` mode doesn't allow the user to specify a port,
setting up the MovR app currently requires the developer to manually insert
the db port into a few places.

This commit creates creates an `init.sh` script to reduce the number
needed to re-initialize database and environment variables in `.env`
file.

In addition to updating README to incorporate how to use `init.sh`,
this commit also updates README to:
- Add instructions on how to create a Google API Key
- Fix `cockroach demo` command to specify `--insecure` flag
- Clarify which instructions/tools are needed for local development vs production deployment.
