### PR TITLE
Added sessionmaker to connection constructor

### DIFF
--- a/movr/movr.py
+++ b/movr/movr.py
@@ -13,12 +13,13 @@ class MovR:
     """
     def __init__(self, conn_string):
         """
-        Establish a connection to the database, creating an Engine instance.
+        Establish a connection to the database, creating Engine and Sessionmaker objects.
 
         Arguments:
             conn_string {String} -- CockroachDB connection string.
         """
         self.engine = create_engine(conn_string, convert_unicode=True)
+        self.sessionmaker = sessionmaker(bind=self.engine)
 
     def start_ride(self, city, rider_id, rider_city, vehicle_id):
         """
@@ -31,7 +32,7 @@ class MovR:
             vehicle_id {UUID} -- The vehicle's unique ID.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine), lambda session: start_ride_txn(
+            self.sessionmaker, lambda session: start_ride_txn(
                 session, city, rider_id, rider_city, vehicle_id))
 
     def end_ride(self, city, ride_id, location):
@@ -44,7 +45,7 @@ class MovR:
             location {String} -- The vehicle's last location.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine),
+            self.sessionmaker,
             lambda session: end_ride_txn(session, city, ride_id, location))
 
     def add_user(self, city, first_name, last_name, email, username, password):
@@ -60,7 +61,7 @@ class MovR:
             password {String} -- The user's unhashed password.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine),
+            self.sessionmaker,
             lambda session: add_user_txn(session, city, first_name, last_name,
                                          email, username, password))
 
@@ -73,7 +74,7 @@ class MovR:
             id {UUID} -- The user's unique ID.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine),
+            self.sessionmaker,
             lambda session: remove_user_txn(session, city, user_id))
 
     def remove_vehicle(self, city, vehicle_id):
@@ -85,7 +86,7 @@ class MovR:
             id {UUID} -- The vehicle's unique ID.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine),
+            self.sessionmaker,
             lambda session: remove_vehicle_txn(session, city, vehicle_id))
 
     def add_vehicle(self,
@@ -113,7 +114,7 @@ class MovR:
             is_owner {bool} -- The owner status of the user, before the vehicle is added. (default: {False})
         """
         return run_transaction(
-            sessionmaker(bind=self.engine), lambda session: add_vehicle_txn(
+            self.sessionmaker, lambda session: add_vehicle_txn(
                 session, city, owner_id, last_location, type, color, brand,
                 status, is_owner))
 
@@ -127,7 +128,7 @@ class MovR:
         Returns:
             List -- A list of dictionaries containing user data.
         """
-        return run_transaction(sessionmaker(bind=self.engine),
+        return run_transaction(self.sessionmaker,
                                lambda session: get_users_txn(session, city))
 
     def get_user(self, username=None, user_id=None):
@@ -142,7 +143,7 @@ class MovR:
             User -- A User object.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine),
+            self.sessionmaker,
             lambda session: get_user_txn(session, username, user_id))
 
     def get_vehicles(self, city):
@@ -155,7 +156,7 @@ class MovR:
         Returns:
             List -- A list of dictionaries containing vehicle data.
         """
-        return run_transaction(sessionmaker(bind=self.engine),
+        return run_transaction(self.sessionmaker,
                                lambda session: get_vehicles_txn(session, city))
 
     def get_rides(self, rider_id):
@@ -169,5 +170,5 @@ class MovR:
             List -- A list of dictionaries containing ride data.
         """
         return run_transaction(
-            sessionmaker(bind=self.engine),
+            self.sessionmaker,
             lambda session: get_rides_txn(session, rider_id))


### PR DESCRIPTION
The `MovR` database connection constructor now creates a single sessionmaker instance that the transaction callbacks can use as a transactor.

Thanks for catching this, @thatnerd!